### PR TITLE
Enforce JWT_SECRET requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ The architecture highlights:
 - Real-time rehydration of user sessions after preference or profile updates
 
 This repo is both a useful app **and** a reference implementation for modern, decoupled web architecture.
+
+## Environment Variables
+
+The OAuth gateway requires a `JWT_SECRET` used to sign tokens. Create an `.env` file in `oauth-express/` and set `JWT_SECRET` to a strong, random string. The application will refuse to start if this variable is missing.

--- a/oauth-express/src/config.ts
+++ b/oauth-express/src/config.ts
@@ -1,5 +1,9 @@
 const dotenv = require('dotenv');
 dotenv.config();
+
+if (!process.env.JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is required');
+}
 const appRoot = require('app-root-path');
 
 export type configInfo = {
@@ -23,7 +27,7 @@ export const config: configInfo = {
     frontendUrl: (process.env.FRONTEND_URL === undefined)?'http://localhost:3001':process.env.FRONTEND_URL,
     googleClientId: (process.env.GOOGLE_CLIENT_ID === undefined)? 'client63839394': process.env.GOOGLE_CLIENT_ID,
     googleClientSecret: (process.env.GOOGLE_CLIENT_SECRET === undefined)? 'client63839394_secret': process.env.GOOGLE_CLIENT_SECRET,
-    jwtSecret: (process.env.JWT_SECRET === undefined)? 'jwt_secret': process.env.JWT_SECRET,
+    jwtSecret: process.env.JWT_SECRET!,
     sessionSecret: (process.env.SESSION_SECRET === undefined)? 'session_secret': process.env.SESSION_SECRET,
     keystone: {
         graphqlUrl: (process.env.KEYSTONE_GRAPHQL_URL === undefined)?'http://localhost:3000/api/graphql':process.env.KEYSTONE_GRAPHQL_URL,


### PR DESCRIPTION
## Summary
- error when JWT_SECRET missing
- document JWT_SECRET setup in README

## Testing
- `npm test` (fails: missing script)
- `npm test` in nextjs-frontend (fails: jest not found)
- `npm test` in keystone-backend (fails: missing script)
