### PR TITLE
Implement JWT issuance

### DIFF
--- a/nextjs-frontend/src/pages/api/logout.ts
+++ b/nextjs-frontend/src/pages/api/logout.ts
@@ -1,13 +1,15 @@
 // /pages/api/logout.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
+import cookie from 'cookie';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
+        const parsed = cookie.parse(req.headers.cookie || '');
+        const token = parsed.token;
+
         const logoutRes = await fetch(`${process.env.OAUTH_HOST}/logout`, {
             method: 'POST',
-            headers: {
-                cookie: req.headers.cookie || '',
-            },
+            headers: token ? { Authorization: `Bearer ${token}` } : {},
         });
 
         const logoutResult = await logoutRes.json();

--- a/nextjs-frontend/src/pages/api/me.ts
+++ b/nextjs-frontend/src/pages/api/me.ts
@@ -1,13 +1,15 @@
 // /pages/api/me.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
+import cookie from 'cookie';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
+        const parsed = cookie.parse(req.headers.cookie || '');
+        const token = parsed.token;
+
         const meRes = await fetch(`${process.env.OAUTH_HOST}/session`, {
             method: 'GET',
-            headers: {
-                cookie: req.headers.cookie || '',
-            },
+            headers: token ? { Authorization: `Bearer ${token}` } : {},
         });
 
         const user = await meRes.json();

--- a/nextjs-frontend/src/pages/api/refresh-session.ts
+++ b/nextjs-frontend/src/pages/api/refresh-session.ts
@@ -1,13 +1,15 @@
 // /pages/api/refresh-session.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
+import cookie from 'cookie';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
+        const parsed = cookie.parse(req.headers.cookie || '');
+        const token = parsed.token;
+
         const response = await fetch(`${process.env.OAUTH_HOST}/refresh-session`, {
             method: 'POST',
-            headers: {
-                cookie: req.headers.cookie || '', // pass browser session cookie
-            },
+            headers: token ? { Authorization: `Bearer ${token}` } : {},
             credentials: 'include',
         });
 

--- a/oauth-express/src/controller/credentials-auth-handler.ts
+++ b/oauth-express/src/controller/credentials-auth-handler.ts
@@ -1,19 +1,32 @@
 import {OAuthControllerInterface} from "./OAuthControllerInterface.js";
 import {ErrorWrapper} from "../error-handler.js";
 import passport from "passport";
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
+import { issueJwt } from "../lib/jwt.js";
 
 export class LoginWithCredentialsHandler implements OAuthControllerInterface {
     errorWrapper = new ErrorWrapper()
 
-    authenticate = (req: Request, res: Response) => {
-        passport.authenticate('google', { scope: ['profile', 'email'] })
-    }
+    authenticate = (req: Request, res: Response, next: NextFunction) => {
+        passport.authenticate('local', (err: unknown, user: any, info: any) => {
+            if (err || !user) {
+                return res.status(401).json({ error: info?.message || 'Login failed' })
+            }
 
-    loginCallback = (req: Request, res: Response) => {
-        passport.authenticate('google', {
-            failureRedirect: '/',
-            successRedirect: `${process.env.FRONTEND_HOST}` // or '/', your homepage, etc.
-        })
+            const token = issueJwt(user)
+
+            res.json({ token, user })
+        })(req, res, next)
+    }
+    loginCallback = (req: Request, res: Response, next: NextFunction) => {
+        passport.authenticate('local', (err: unknown, user: any, info: any) => {
+            if (err || !user) {
+                return res.status(401).json({ error: info?.message || 'Login failed' })
+            }
+
+            const token = issueJwt(user)
+
+            res.json({ token, user })
+        })(req, res, next)
     }
 }

--- a/oauth-express/src/controller/google-auth-handler.ts
+++ b/oauth-express/src/controller/google-auth-handler.ts
@@ -1,19 +1,32 @@
 import {OAuthControllerInterface} from "./OAuthControllerInterface.js";
 import {ErrorWrapper} from "../error-handler.js";
 import passport from "passport";
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
+import { issueJwt } from "../lib/jwt.js";
 
 export class GoogleAuthHandler implements OAuthControllerInterface {
     errorWrapper = new ErrorWrapper()
 
-    authenticate = (req: Request, res: Response) => {
-        passport.authenticate('google', { scope: ['profile', 'email'] })
+    authenticate = (req: Request, res: Response, next: NextFunction) => {
+        passport.authenticate('google', { scope: ['profile', 'email'] })(req, res, next)
     }
 
-    loginCallback = (req: Request, res: Response) => {
-        passport.authenticate('google', {
-            failureRedirect: '/',
-            successRedirect: `${process.env.FRONTEND_HOST}` // or '/', your homepage, etc.
-        })
+    loginCallback = (req: Request, res: Response, next: NextFunction) => {
+        passport.authenticate('google', (err: unknown, user: any) => {
+            if (err || !user) {
+                return res.redirect('/')
+            }
+
+            const token = issueJwt(user)
+
+            res.cookie('token', token, {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === 'production',
+                sameSite: 'lax',
+                maxAge: 1000 * 60 * 60 * 24 * 7,
+            })
+
+            res.redirect(`${process.env.FRONTEND_HOST}`)
+        })(req, res, next)
     }
 }


### PR DESCRIPTION
## Summary
- issue JWT in google and credentials controllers
- attach JWT cookie on Google auth flow
- return `{ token, user }` for local login
- send Authorization header with token from cookie in frontend APIs

## Testing
- `npx tsc --noEmit` *(fails: Cannot find name 'require')*