### PR TITLE
Apply JWT auth middleware selectively

### DIFF
--- a/oauth-express/src/lib/jwt.ts
+++ b/oauth-express/src/lib/jwt.ts
@@ -15,7 +15,7 @@ export const issueJwt = (user: KeystoneUser): string => {
     return jwt.sign(payload, process.env.JWT_SECRET!, { expiresIn: '7d' });
 }
 
-export const veriyfJwt = (req: Request, res: Response, next: NextFunction) => {
+export const verifyJwt = (req: Request, res: Response, next: NextFunction) => {
     const authHeader = req.headers['authorization'] as string | undefined;
 
     if (authHeader === undefined || !authHeader?.startsWith('Bearer ')) {

--- a/oauth-express/src/middleware/index.ts
+++ b/oauth-express/src/middleware/index.ts
@@ -2,11 +2,9 @@ import {setupJsonBodyParse} from "./jsonParser.js";
 import {Application} from "express";
 import {setupSession} from "./session.js";
 import {setupPassport} from "./passport.js";
-import {setupJwtValidation} from "./jwt.js";
 
 export default (app: Application) => {
     setupJsonBodyParse(app)
     setupSession(app)
     setupPassport(app)
-    setupJwtValidation(app)
 }

--- a/oauth-express/src/middleware/jwt.ts
+++ b/oauth-express/src/middleware/jwt.ts
@@ -1,6 +1,1 @@
-import {Application} from "express";
-import {veriyfJwt} from "../lib/jwt";
-
-export const setupJwtValidation = (app: Application) => {
-    app.use(veriyfJwt)
-}
+export { verifyJwt } from "../lib/jwt";

--- a/oauth-express/src/routes/genericAuthRouter.ts
+++ b/oauth-express/src/routes/genericAuthRouter.ts
@@ -2,6 +2,7 @@ import express, { Application, Request, Response, NextFunction } from 'express'
 import { config } from "../config";
 import { corsOptions } from '../lib/cors-setup'
 import {GenericAuthHandler} from "../controller/generic-auth-handler.js";
+import { verifyJwt } from "../middleware/jwt.js";
 
 export const setupGenericAuthRoutes = (app: Application) => {
     const router = express.Router()
@@ -14,6 +15,8 @@ export const setupGenericAuthRoutes = (app: Application) => {
         console.log(`Generic Auth request: ${req.url}`)
         next()
     })
+
+    router.use(verifyJwt)
 
     router.get("/session", genericHandlerController.getUserSession)
 


### PR DESCRIPTION
## Summary
- rename `veriyfJwt` to `verifyJwt`
- stop mounting JWT middleware globally
- apply `verifyJwt` only on authenticated routes

## Testing
- `npm run build` *(fails: cannot find various types)*